### PR TITLE
Use run_id and update response text format

### DIFF
--- a/alfalfa_client/alfalfa_client.py
+++ b/alfalfa_client/alfalfa_client.py
@@ -28,7 +28,6 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ****************************************************************************************************
 """
 
-import json
 from multiprocessing import Pool
 
 import requests
@@ -154,7 +153,7 @@ class AlfalfaClient:
         payload = {'query': query}
         response = requests.post(self.url + '/graphql', json=payload)
 
-        j = json.loads(response.text)
+        j = response.json()
         points = j["data"]["viewer"]["sites"][0]["points"]
         result = {}
 
@@ -176,7 +175,7 @@ class AlfalfaClient:
         payload = {'query': query}
         response = requests.post(self.url + '/graphql', json=payload)
 
-        j = json.loads(response.text)
+        j = response.json()
         points = j["data"]["viewer"]["sites"][0]["points"]
         result = []
 
@@ -196,7 +195,7 @@ class AlfalfaClient:
         payload = {'query': query}
         response = requests.post(self.url + '/graphql', json=payload)
 
-        j = json.loads(response.text)
+        j = response.json()
         points = j["data"]["viewer"]["sites"][0]["points"]
         result = {}
 
@@ -216,7 +215,7 @@ class AlfalfaClient:
         payload = {'query': query}
         response = requests.post(self.url + '/graphql', json=payload)
 
-        j = json.loads(response.text)
+        j = response.json()
         dt = j["data"]["viewer"]["runs"]["sim_time"]
         return dt
 
@@ -229,7 +228,7 @@ class AlfalfaClient:
         payload = {'query': query}
         response = requests.post(self.url + '/graphql', json=payload)
 
-        j = json.loads(response.text)
+        j = response.json()
         points = j["data"]["viewer"]["sites"][0]["points"]
         result = []
 
@@ -247,7 +246,7 @@ class AlfalfaClient:
         payload = {'query': query}
         response = requests.post(self.url + '/graphql', json=payload)
 
-        j = json.loads(response.text)
+        j = response.json()
         points = j["data"]["viewer"]["sites"][0]["points"]
         result = []
 
@@ -323,7 +322,7 @@ class AlfalfaClient:
         payload = {'query': query}
         response = requests.post(self.url + '/graphql', json=payload)
 
-        j = json.loads(response.text)
+        j = response.json()
         points = j["data"]["viewer"]["sites"][0]["points"]
         result = {}
 

--- a/alfalfa_client/lib.py
+++ b/alfalfa_client/lib.py
@@ -155,16 +155,18 @@ def submit_one(args):
     # After the file has been uploaded, then tell BOPTEST to process the site
     # This is done not via the haystack api, but through a graphql api
     mutation = 'mutation { addSite(modelName: "%s", uploadID: "%s") }' % (filename, uid)
+    run_id = None
     for _ in range(3):
         response = requests.post(url + '/graphql', json={'query': mutation})
         if response.status_code == 200:
+            run_id = response.json()['data']['addSite']
             break
     if response.status_code != 200:
         print("Could not addSite")
 
-    wait(url, uid, "READY")
+    wait(url, run_id, "READY")
 
-    return uid
+    return run_id
 
 
 def start_one(args):

--- a/alfalfa_client/lib.py
+++ b/alfalfa_client/lib.py
@@ -28,7 +28,6 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ****************************************************************************************************
 """
 
-import json
 import os
 import time
 import uuid
@@ -70,7 +69,7 @@ def status(url, run_id):
     if response.status_code != 200:
         print("Could not get status")
 
-    j = json.loads(response.text)
+    j = response.json()
     runs = j["data"]["viewer"]["runs"]
     if runs:
         status = runs["status"]
@@ -89,7 +88,7 @@ def get_error_log(url, run_id):
     if response.status_code != 200:
         print("Could not get error log")
 
-    j = json.loads(response.text)
+    j = response.json()
     runs = j["data"]["viewer"]["runs"]
     if runs:
         error_log = runs["error_log"]

--- a/tox.ini
+++ b/tox.ini
@@ -6,5 +6,5 @@ envlist = python3.7, python3.8, python3.9
 whitelist_externals = poetry
 commands =
     poetry install -v
-    poetry run pytest tests/
+    poetry run pytest tests
     poetry run pre-commit run -a


### PR DESCRIPTION
This takes the latest fix from @TShapinsky and add a style update to return JSON from a request.

AFAIK this only works on the `add-mongoengine` branch of Alfalfa, so do not merge until that is in develop.