### PR TITLE
Handle outputs before values are populated

### DIFF
--- a/alfalfa_client/alfalfa_client.py
+++ b/alfalfa_client/alfalfa_client.py
@@ -283,7 +283,10 @@ class AlfalfaClient:
         response_body = response.json()
         outputs = {}
         for point in response_body["data"]:
-            outputs[point["name"]] = point["value"]
+            if "value" in point.keys():
+                outputs[point["name"]] = point["value"]
+            else:
+                outputs[point["name"]] = None
 
         return outputs
 


### PR DESCRIPTION
Previously if you tried to read the outputs before the site was running you would get a key does not exist error. This makes it assign `None` to the value of that point instead