### PR TITLE
Remove deprecated pkg_resources

### DIFF
--- a/alfalfa_client/__init__.py
+++ b/alfalfa_client/__init__.py
@@ -26,9 +26,4 @@
 # OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # ****************************************************************************************************
 
-
-import pkg_resources
-
 from alfalfa_client.alfalfa_client import AlfalfaClient
-
-__version__ = pkg_resources.get_distribution('alfalfa-client').version


### PR DESCRIPTION
`pkg_resources` has been deprecated and version information now comes from the pyproject.toml. The code removed here doesn't do anything.